### PR TITLE
extracted the tree_path information into a variable so it only has to be changed once if needed.

### DIFF
--- a/tarmac.conf
+++ b/tarmac.conf
@@ -1,35 +1,39 @@
+[DEFAULT]
+branch_root = /home/zyga/.cache/tarmac/branches
+
 [Tarmac]
 
 [lp:checkbox]
-tree_dir = /home/zyga/.cache/tarmac/branches/checkbox/trunk
+tree_dir = %(branch_root)s/checkbox/trunk
 verify_command = ./tarmac-verify
 commit_message_template = "[r=<approved_by_nicks>][bug=<bugs_fixed>][author=<author_nick>] <commit_message>"
 
 [lp:cloud-testing]
-tree_dir = /home/zyga/.cache/tarmac/branches/cloud-testing/trunk
+tree_dir = %(branch_root)s/cloud-testing/trunk
 commit_message_template = "[r=<approved_by_nicks>][bug=<bugs_fixed>][author=<author_nick>] <commit_message>"
 
 [lp:checkbox/release]
-tree_dir = /home/zyga/.cache/tarmac/branches/checkbox/release
+tree_dir = %(branch_root)s/checkbox/release
 verify_command = VAGRANT_DONE_ACTION=destroy ./test-in-vagrant.sh
 commit_message_template = "[r=<approved_by_nicks>][bug=<bugs_fixed>][author=<author_nick>] <commit_message>"
 
 [lp:checkbox-certification]
-tree_dir = /home/zyga/.cache/tarmac/branches/checkbox-certification/trunk
+tree_dir = %(branch_root)s/checkbox-certification/trunk
 commit_message_template = "[r=<approved_by_nicks>][bug=<bugs_fixed>][author=<author_nick>] <commit_message>"
 
 [lp:checkbox-certification/release]
-tree_dir = /home/zyga/.cache/tarmac/branches/checkbox-certification/release
+tree_dir = %(branch_root)s/checkbox-certification/release
 commit_message_template = "[r=<approved_by_nicks>][bug=<bugs_fixed>][author=<author_nick>] <commit_message>"
 
 [lp:checkbox-satellite]
-tree_dir = /home/zyga/.cache/tarmac/branches/checkbox-satellite/trunk
+tree_dir = %(branch_root)s/checkbox-satellite/trunk
 commit_message_template = "[r=<approved_by_nicks>][bug=<bugs_fixed>][author=<author_nick>] <commit_message>"
 
 [lp:checkbox-ihv]
-tree_dir = /home/zyga/.cache/tarmac/branches/checkbox-ihv/trunk
+tree_dir = %(branch_root)s/checkbox-ihv/trunk
 commit_message_template = "[r=<approved_by_nicks>][bug=<bugs_fixed>][author=<author_nick>] <commit_message>"
 
 [lp:~hardware-certification/checkbox-satellite/message]
-tree_dir = /home/zyga/.cache/tarmac/branches/checkbox-satellite/message
+tree_dir = %(branch_root)s/checkbox-satellite/message
 commit_message_template = "[r=<approved_by_nicks>][bug=<bugs_fixed>][author=<author_nick>] <commit_message>"
+


### PR DESCRIPTION
Added a base path for the local branches and replaced the hardcoded paths
with this variable, to avoid error-prone repetition if relocating
tarmac's data dirs.
