### PR TITLE
Added lp:capomastro to the list of projects to process

### DIFF
--- a/tarmac.conf
+++ b/tarmac.conf
@@ -122,3 +122,8 @@ commit_message_template = "<commit_message> [r=<approved_by_nicks>][bug=<bugs_fi
 tree_dir = %(branch_root)s/plainbox-provider-barajas/trunk
 verify_command = ./tarmac-verify
 commit_message_template = "<commit_message> [r=<approved_by_nicks>][bug=<bugs_fixed>][author=<author_nick>]"
+
+[lp:capomastro]
+tree_dir = %(branch_root)s/capomastro/trunk
+verify_command = ./tarmac-verify
+commit_message_template = "<commit_message> [r=<approved_by_nicks>][bug=<bugs_fixed>][author=<author_nick>]"


### PR DESCRIPTION
Capomastro now provides a tarmac-verify script that runs the test suite using lxc (similar to the harness used for lp:checkbox and friends).
